### PR TITLE
feat: add initial documentation contents based on the current tiptap docs

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -25,6 +25,23 @@ module.exports = {
                         'styling/basics',
                     ]
                 },
+                {
+                    title: 'Extensions',
+                    collapsable: false,
+                    children: [
+                        'extensions/basics.md',
+                        'extensions/built-in.md'
+                    ]
+                },
+                {
+                    title: 'API',
+                    collapsable: false,
+                    children: [
+                        'api/classes',
+                        'api/components',
+                        'api/plugins'
+                    ]
+                }
             ],
         },
         nav: [

--- a/README.md
+++ b/README.md
@@ -1,3 +1,55 @@
+> 🚧 This is a work in progress and contributions are welcome. Read the tiptap [contribution guidelines][@tiptap-contrib]
+> and help us shape the documentation.
+
 # Introduction
 
-🚧 Work in Progress
+tiptap is a _renderless_ and extendable rich-text editor for [Vue.js](https://github.com/vuejs/vue)
+
+## Why tiptap was built
+The guys behind [Scrumpy][@scrumpy] were looking for a text editor for [Vue.js][@vuejs] and 
+found some solutions that didn't really satisfy their needs. The editor should be easy to extend and not based on old dependencies
+such as jQuery. For React there is already a great editor called [Slate.js][@slatejs], 
+which impresses with its modularity. They came across [Prosemirror][@prosemirror] and decided to build
+on top of it. [Prosemirror][@prosemirror] is a toolkit for building rich-text editors that are already in use at many well-known companies such as *Atlassian* or *New York Times*.
+
+### What does `renderless` mean?
+
+With renderless components you'll have (almost) full control over markup and styling. tiptap doesn't tell you what a menu should look like or where it should be rendered in the DOM. That's all up to you. There is also a [good article](@renderless) about renderless components by Adam Wathan.
+
+### How is the data stored under the hood?
+
+You can save your data as a raw `HTML` string or can get a `JSON`-serializable representation of your document. And of course, you can pass these two types back to the editor.
+
+## Examples
+To check out some live examples, visit [tiptap.scrumpy.io][@tiptap-examples].
+
+## Contributing
+
+Please see the [`CONTRIBUTING`][@tiptap-contrib] file for details. If you want to contribute with 
+[the documentation][@tiptap-docs], install its dependencies and run [Vuepress][@vuepress]
+
+```
+yarn install
+yarn start
+```
+
+## Credits
+
+- [Philipp Kühn](https://github.com/philippkuehn)
+- [Christoph Flathmann](https://github.com/Chrissi2812)
+- [All Contributors](https://github.com/scrumpy/tiptap/contributors)
+
+## License
+
+The MIT License (MIT). Please see the [License File][@tiptap-license] for more information.
+
+[@prosemirror]: https://github.com/prosemirror
+[@renderless]: https://adamwathan.me/renderless-components-in-vuejs/
+[@scrumpy]: https://scrumpy.io
+[@slatejs]: https://github.com/ianstormtaylor/slate
+[@tiptap-contrib]: https://github.com/scrumpy/tiptap/blob/master/CONTRIBUTING.md
+[@tiptap-docs]: https://github.com/scrumpy/tiptap-docs
+[@tiptap-examples]: https://tiptap.scrumpy.io/
+[@tiptap-license]: https://github.com/scrumpy/tiptap/blob/master/LICENSE.md
+[@vuejs]: https://vuejs.org/
+[@vuepress]: https://vuepress.vuejs.org/

--- a/api/classes.md
+++ b/api/classes.md
@@ -1,0 +1,360 @@
+> 🚧 This is a work in progress and contributions are welcome. Read the tiptap [contribution guidelines][@tiptap-contrib]
+> and help us shape the documentation.
+
+
+# Global
+
+[[toc]]
+
+## Editor
+This class is a central building block of tiptap. It does most of the heavy lifting of creating a working Prosemirror
+editor such as creating the [`EditorView`][@prosemirror-view], setting the initial 
+[`EditorState`][@prosemirror-state] and so on.
+
+Although tiptap tries to hide most of the complexity of [Prosemirror][@prosemirror], tiptap is built on top of its APIs
+and we strongly recommend you to read through the [Prosemirror Guide][@prosemirror-guide]. You'll have a better 
+understanding of how everything works under the hood and get familiar with many terms and jargon used by tiptap.
+
+### Usage
+You must create an instance of `Editor` class and pass it to the [`EditorContent`](components.md#editor-content) 
+component. The `Editor` constructor accepts an object of [editor options](#editor-options).
+
+#### Example
+```vue
+<template>
+  <editor-content :editor="editor" />
+<template>
+
+<script>
+import { Editor, EditorContent } from 'tiptap'
+
+export default {
+    data() {
+        editor: null
+    },
+    mounted() {
+        const options = {
+            content: '<p>Initial editor content</p>'
+        }
+        this.editor = new Editor(options)
+    }
+}
+</script>
+```
+### Instance properties
+
+#### commands 
+#### defaultOptions
+#### element
+#### extensions 
+#### inputRules 
+#### keymaps 
+#### marks 
+#### nodes 
+#### pasteRules 
+#### plugins 
+#### schema 
+#### state 
+#### view 
+
+### Methods
+
+#### constructor([options])
+
+- **Arguments** 
+  - `{object} options` an object of [Editor options](#editor-options)
+
+#### setContent(content = {}, emitUpdate = false)
+Replace the current content. You can pass an HTML string or a JSON document that matches the editor's [`schema`][@prosemirror-schema].
+
+- **Arguments:**
+  - `{object} content` HTML string or a JSON document
+  - `{boolean} emitUpdate` whether or not the change should trigger the [`onUpdate`](#onupdate-context) callback.
+
+
+#### clearContent(emitUpdate = false)
+Clears the current editor content.
+
+- **Arguments:**
+  - `{boolean} emitUpdate` whether or not the change should trigger the [`onUpdate`](#onupdate-context) callback.
+
+#### setOptions(options)
+Overwrites the current editor options.
+
+- **Arguments:**
+  - `{object} options` an object of [Editor options](#editor-options)
+
+#### registerPlugin(plugin)
+Register a Prosemirror plugin.
+
+#### getJSON()
+Get the current content as JSON.
+
+#### getHTML()
+Get the current content as HTML.
+
+#### focus()
+Focus the editor.
+
+#### blur()
+Removes the focus from the editor.
+
+#### destroy()
+Destroy the editor and free all Prosemiror-related objects from memory. You should always call this method on 
+`beforeDestroy()` lifecycle hook of the Vue component wrapping the editor.
+
+
+## Editor options
+An object passed down to the `Editor` constructor to change it's behaviour.
+
+```js
+{
+  editorProps: {},
+  editable: true,
+  autoFocus: false,
+  extensions: [],
+  content: '',
+  emptyDocument: {
+    type: 'doc',
+    content: [{
+      type: 'paragraph',
+    }],
+  },
+  useBuiltInExtensions: true,
+  dropCursor: {},
+  onInit: () => {},
+  onUpdate: () => {},
+  onFocus: () => {},
+  onBlur: () => {},
+  onPaste: () => {},
+  onDrop: () => {},
+}
+```
+### Attributes
+#### editorProps
+- **Details:** An object describing [Prosemirror EditorProps][@prosemirror-editor-props].
+- **Type:** `EditorProps`
+- **Required:** `false`
+- **Default:** `{}`
+- **Example:**
+  ```js
+  new Editor({
+    // other options omitted for brevity
+    editorProps: {
+      handlePaste: () => {
+        console.log(`Some new content was added from the user's clipboard`)
+      }
+    }
+  })
+  ```
+
+::: tip
+The example above can be simplified by using the [`onPaste` option](#onpaste).
+:::
+
+#### editable
+- **Details:** When set to `false` the editor is read-only.
+- **Type:** `boolean`
+- **Required:** `false`
+- **Default:** `true`
+
+#### autoFocus
+- **Details:** Move the focus the editor after its initialization.
+- **Type:** `boolean`
+- **Required:** `false`
+- **Default:** `false`
+
+#### extensions
+- **Details:** A list of extensions used by the editor. This list may contain `Nodes`, `Marks`,
+  or [`Plugins`](plugins.md). Check the [extensions guide][@extensions-guide] for more information.
+- **Type:** `Array<Node | Mark | Plugin>`
+- **Required:** `false`
+- **Default:** `[]`
+
+#### content
+
+- **Details:** the editor state object used by Prosemirror. You can also pass HTML to the `content` slot of the 
+  [`EditorContent`component](components.md#editor-content). This option has priority and when _both_ slot and option is 
+  used, the `content` slot will be ignored.
+- **Type**: `string |  object`
+- **Required:**: `false`
+- **Default:** `null`
+- **Restriction**: both the HTML string and JSON elements are bound to the [document schema][@doc-schema]. Any tag not 
+  defined in the schema is ignored.
+
+#### emptyDocument
+- **Details**: contains the initial Prosemirror document specification used to render  an empty document. You may override it with a custom schema.
+- **Type:**: `object`
+- **Required:**: `false`
+- **Default:**
+  ```js
+  {
+    type: 'doc',
+    content: [{
+      type: 'paragraph',
+    }],
+  }
+  ```
+
+#### useBuiltInExtensions
+- **Details:** By default tiptap adds a `Doc`, `Paragraph` and `Text` node to the Prosemirror schema. Set this to `false`
+  if you want to change the default structure of how your document is generated.
+- **Type:** `boolean`
+- **Required:** `false`
+- **Default:** `true`
+
+#### dropCursor
+- **Details:** Configuration options for [`prosemirror-dropcursor`][@prosemirror-dropcursor].
+- **Type:** `object`
+- **Required:** `false`
+- **Default:** `{}`
+
+#### onInit()
+- **Details:** This will be called with an object containing [`state`][@prosemirror-state] and [`view`][@prosemirror-view] 
+  from Prosemirror once the editor is initialized.
+- **Type:** `Function`
+- **Required:** `false`
+- **Default:** `() => {}`
+- **Example**:
+  ```js
+  new Editor({
+    // other options omitted for brevity
+    onInit: ({ state, view }) => {
+      console.log(state)
+      console.log(view)
+    }
+  })
+  ```
+#### onUpdate(context)
+- **Details:** This will be called with a context object containing the current [`state`][@prosemirror-state] of Prosemirror,
+  a `getJSON()` and `getHTML()` functions, and the [`transaction`][@prosemirror-transaction] on every change made to the editor.
+- **Type:** `Function`
+- **Required:** `false`
+- **Default:** `() => {}`
+- **Example:**
+  ```js
+  new Editor({
+    // other options omitted for brevity
+    onUpdate( { state, getHTML, getJSON, transaction } ) => {
+      console.log(state, transaction)
+      console.log(getHTML(), getJSON())
+    }
+  })
+  ```
+
+#### onFocus()
+- **Details:** This will be called and object containing the [focus `event`][@mdn-focus-event], the current 
+  [`state`][@prosemirror-state], and [`view`][@prosemirror-view] from Prosemirror whenever the editor _receives_ focus.
+- **Type:** `Function`
+- **Required:** `false`
+- **Default:** `() => {}`
+- **Example**:
+  ```js
+  new Editor({
+    // other options omitted for brevity
+    onFocus: ({ event,  state, view }) => {
+      console.log(event, state, view)
+    }
+  })
+  ```
+
+#### onBlur()
+- **Details:** This will be called and object containing the [blur `event`][@mdn-blur-event], the current 
+  [`state`][@prosemirror-state], and [`view`][@prosemirror-view] from Prosemirror whenever the editor _loses_ focus.
+- **Type:** `Function`
+- **Required:** `false`
+- **Default:** `() => {}`
+- **Example**:
+  ```js
+  new Editor({
+    // other options omitted for brevity
+    onBlur: ({ event,  state, view }) => {
+      console.log(event, state, view)
+    }
+  })
+  ```
+
+#### onPaste()
+- **Details:** This will be called whenever some content from the user's clipboard is pasted into the editor.
+- **Type:** `Function`
+- **Required:** `false`
+- **Default:** `() => {}`
+- **Example**:
+  ```js
+  new Editor({
+    // other options omitted for brevity
+    onPaste: () => {
+      console.log(`New content was added from the user's clipboard!`)
+    }
+  })
+  ```
+
+#### onDrop()
+- **Details:** This will be called whenever the users drags and _drop_ some object into the editor view (i.e., an image, or file). This is a wrapper around [`handleDrop` editor prop](@prosemirror-editor-props)
+- **Type:** `Function`
+- **Required:** `false`
+- **Default:** `() => {}`
+- **Example**:
+  ```js
+  new Editor({
+    // other options omitted for brevity
+    onDrop: (view, event, slice, moved) => {
+      console.log(`New content was added from the user's clipboard!`)
+      console.log(view, event, slice, moved)
+    }
+  })
+  ```
+
+## Extension
+### Usage
+TBD
+### Methods
+TBD
+### Instance properties
+TBD
+
+## ExtensionManager
+### Usage
+TBD
+### Methods
+TBD
+### Instance properties
+TBD
+
+## ComponentView
+### Usage
+TBD
+### Methods
+TBD
+### Instance properties
+TBD
+
+## Node
+### Usage
+TBD
+### Methods
+TBD
+### Instance properties
+TBD
+
+## Mark
+### Usage
+TBD
+### Methods
+TBD
+### Instance properties
+TBD
+
+[@tiptap-contrib]: https://github.com/scrumpy/tiptap/blob/master/CONTRIBUTING.md
+[@doc-schema]: https://prosemirror.net/docs/ref/#model.Document_Schema
+[@extensions-guide]: ../extensions/basics.md
+[@prosemirror-dropcursor]: https://github.com/ProseMirror/prosemirror-dropcursor
+[@prosemirror-editor-props]: https://prosemirror.net/docs/ref/#view.EditorProps
+[@prosemirror-guide]: https://prosemirror.net/docs/guide/
+[@prosemirror-state]: https://prosemirror.net/docs/ref/#state.Editor_State
+[@prosemirror-transaction]: https://prosemirror.net/docs/ref/#state.Transaction
+[@prosemirror-schema]: https://prosemirror.net/docs/ref/#model.Document_Schema
+[@prosemirror-view]: https://prosemirror.net/docs/ref/#view.EditorView
+[@prosemirror]: https://prosemirror.net/docs/
+[@mdn-focus-event]: https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event
+[@mdn-blur-event]: https://developer.mozilla.org/en-US/docs/Web/API/Element/blur_event

--- a/api/components.md
+++ b/api/components.md
@@ -1,0 +1,7 @@
+> 🚧 This is a work in progress and contributions are welcome. Read the tiptap [contribution guidelines][@tiptap-contrib]
+> and help us shape the documentation.
+
+# Components
+TBD
+
+[@tiptap-contrib]: https://github.com/scrumpy/tiptap/blob/master/CONTRIBUTING.md

--- a/api/plugins.md
+++ b/api/plugins.md
@@ -1,0 +1,34 @@
+> 🚧 This is a work in progress and contributions are welcome. Read the tiptap [contribution guidelines][@tiptap-contrib]
+> and help us shape the documentation.
+
+# Plugins
+[[toc]]
+
+## FloatingMenu
+### Usage
+### Instance properties
+
+#### options
+#### editorView
+#### isActive
+#### top
+
+### Methods
+
+#### constructor({ options, editorView })
+#### update(view, lastState)
+#### sendUpdate()
+#### hide()
+#### destroy()
+
+## MenuBubble
+
+### Usage
+
+### Instance properties
+#### options
+#### options
+
+### Methods
+
+[@tiptap-contrib]: https://github.com/scrumpy/tiptap/blob/master/CONTRIBUTING.md

--- a/extensions/basics.md
+++ b/extensions/basics.md
@@ -1,0 +1,42 @@
+> 🚧 This is a work in progress and contributions are welcome. Read the tiptap [contribution guidelines][@tiptap-contrib]
+> and help us shape the documentation.
+
+
+# Extensions
+[`tiptap-extensions`](@tiptap-extensions) is a package containing many ready-made components officially maintained
+by the tiptap project maintainers and community. It's goal is to minimise the effort to implement your own editor
+features while keeping the core design principles of a _renderless_ editor.
+
+The extensions package provides Prosemirror plugins, Nodes, or Marks that can be added to to tiptap. You are free to 
+implement your own extensions as well. By using them, you barely have to think about defining your own Prosemirror 
+Document schema, as it is dynamically composed based on all extensions you have registered with your 
+[`Editor` instance](../api/classes.md#editor)
+
+For a full list of officially supported extensions, check the [built-in extensions list](./built-in.md) section in the documentation.
+
+[[toc]]
+
+## Usage
+
+### Example
+
+```js
+import { Blockquote } from 'tiptap-extensions'
+new Editor({
+  // other options omitted for brevity
+  extensions: [
+      // The editor will accept paragraphs and `<blockquote>` elements as part of its document schema.
+      Blockquote
+  ]
+})
+```
+
+## Anatomy of an extension
+TBD
+
+## Writing your own extensions
+TBD
+
+
+[@tiptap-contrib]: https://github.com/scrumpy/tiptap/blob/master/CONTRIBUTING.md
+[@tiptap-extensions]: https://www.npmjs.com/package/tiptap-extensions

--- a/extensions/built-in.md
+++ b/extensions/built-in.md
@@ -1,0 +1,6 @@
+> 🚧 This is a work in progress and contributions are welcome. Read the tiptap [contribution guidelines][@tiptap-contrib]
+> and help us shape the documentation.
+
+# Built-in extensions
+
+[@tiptap-contrib]: https://github.com/scrumpy/tiptap/blob/master/CONTRIBUTING.md

--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -1,1 +1,12 @@
 # Installation
+
+Install the `tiptap` package with your favorite package manager:
+```
+npm add tiptap
+```
+or
+```
+yarn add tiptap
+```
+
+> Older versions of NPM requires you to use `npm install` instead.

--- a/getting-started/usage.md
+++ b/getting-started/usage.md
@@ -1,1 +1,40 @@
 # Basic Usage
+
+You can create a working editor with very little code. The basic building blocks you need are the 
+[`Editor` class][@editor-class] and the [`EditorContent` component][@editor-content-component]
+
+```vue
+<template>
+  <editor-content :editor="editor" />
+</template>
+
+<script>
+// Import the basic building blocks
+import { Editor, EditorContent } from 'tiptap'
+
+export default {
+  components: {
+    EditorContent,
+  },
+  data() {
+    return {
+      editor: null,
+    }
+  },
+  mounted() {
+    // Create an `Editor` instance with some default content. The editor is 
+    // then passed to the `EditorContent` component as a `prop`
+    this.editor = new Editor({
+      content: '<p>This is just a boring paragraph</p>',
+    })
+  },
+  beforeDestroy() {
+    // Always destroy your editor instance when it's no longer needed
+    this.editor.destroy()
+  },
+}
+</script>
+```
+
+[@editor-class]: ../api/classes.md#editor
+[@editor-content-component]: https://github.com/scrumpy/tiptap/blob/master/packages/tiptap/src/Components/EditorContent.js

--- a/styling/basics.md
+++ b/styling/basics.md
@@ -1,1 +1,1 @@
-# Basics
+# Basic styling


### PR DESCRIPTION
This is an initial effort to start addressing [tiptap#162](https://github.com/scrumpy/tiptap/issues/162)

> ℹ️ Note to the maintainers
> This initial set of changes were based on both the existing `README.md` file from tiptap _and_ my own mental model of how things are connected and works. It might contain some misconceptions regarding references to Prosemirror resources - I would suggest you to review the terms/jargon used to see if there is something that I've missed or it was poorly explained.

So far I'm looking forward to seeing the docs getting revamped as I believe it could help to get more users (and collaborators) into tiptap/Prosemirror

## Main changes
* feat(readme): add introductory text from tiptap repo and basic instructions for
  contribution to the docs repo with `vuepress`
* feat(gettings-started): add basic setup docs based on the current tiptap docs
* feat(api): add basic API documentation
  It covers the `Editor` class and editor options plus a basic outline of core classes
  It loosely follows the same pattern found on a project like Vue itself, or Vuex to document
  options, methods et al
* feat(extensions): add basic extensions description an document anatomy.