### PR TITLE
added documentation about tables

### DIFF
--- a/extensions/built-in.md
+++ b/extensions/built-in.md
@@ -174,6 +174,109 @@ usually tied to a [Command](../commands/basics.md). The official set of commands
   ```vue
   ```
 
+## Table
+This enables support for tables in your editor.
+Tables can be nested and allow all blocks to be used inside.
+Each `<TableCell>` includes a single `<Paragraph>`.
+
+### Options <Badge text="1.19.3"/>
+| option | type | default | description |
+| ------ | ---- | ---- | ----- |
+| resizable | boolean | false | Enables the resizing of columns |
+### Default Keybindings
+- `Tab` Next Cell
+- `Shift-Tab` Previous Cell 
+
+### Commands
+| command | options | description |
+| ------ | ---- | ---------------- |
+| createTable | ```{ rowsCount, colsCount, withHeaderRow }``` | Returns a table node of a given size. `withHeaderRow` defines whether the first row of the table will be a header row. |
+| deleteTable | none | Deletes the complete table which is active |
+| addColumnBefore | none | Add a column before the selection. |
+| addColumnAfter | none | Add a column after the selection. |
+| deleteColumn | none | Removes the selected columns. |
+| addRowBefore | none | Add a table row before the selection. |
+| addRowAfter | none | Add a table row after the selection. |
+| toggleCellMerge | none | See mergeCells and splitCells |
+| mergeCells | none | Merge the selected cells into a single cell. Only available when the selected cells' outline forms a rectangle. |
+| splitCell | none | Split a selected cell, whose rowspan or colspan is greater than one into smaller cells. |
+| toggleHeaderColumn | none | Toggles whether the selected column contains header cells. |
+| toggleHeaderRow | none | Toggles whether the selected row contains header cells. |
+| toggleHeaderCell | none | Toggles whether the selected column contains header cells. |
+| setCellAttr | none | Returns a command that sets the given attribute to the given value, and is only available when the currently selected cell doesn't already have that attribute set to that value. |
+| fixTables | none | Inspect all tables in the given state's document and return a transaction that fixes them, if necessary. |
+
+#### Example
+::: warning
+You have to include all table extensions (`TableHeader`, `TableCell` & `TableRow`)
+:::
+
+  ```vue
+  <template>
+      <div>
+        <editor-menu-bar :editor="editor">
+          <div slot-scope="{ commands, isActive }">
+              <button :class="{ 'is-active': isActive.bold() }" @click="commands.createTable({rowsCount: 3, colsCount: 3, withHeaderRow: false })">
+                Create Table
+              </button>
+          </div>
+        </editor-menu-bar>
+  
+        <editor-content :editor="editor" />
+      </div>
+    </template>
+  
+    <script>
+    import { Editor, EditorContent, EditorMenuBar } from 'tiptap'
+    import { Table, TableCell, TableHeader, TableRow } from 'tiptap-extensions'
+  
+  
+    export default {
+      components: {
+          EditorMenuBar,
+          EditorContent,
+      },
+      data() {
+        return {
+          editor: new Editor({
+            extensions: [
+              new Table(),
+              new TableCell(),
+              new TableHeader(),
+              new TableRow(),
+            ],
+            content: ''
+          }),
+        }
+      },
+      beforeDestroy() {
+        this.editor.destroy()
+      }
+    }
+    </script>
+  ```
+
+## TableHeader
+::: warning Restrictions
+This extensions is intended to be used with the `Table` extension.
+:::
+- **Description:** allows you to use the `<th>` HTML tag in the editor
+- **Type:** Node
+
+## TableCell
+::: warning Restrictions
+This extensions is intended to be used with the `Table` extension.
+:::
+- **Description:** allows you to use the `<td>` HTML tag in the editor
+- **Type:** Node
+
+## TableRow
+::: warning Restrictions
+This extensions is intended to be used with the `Table` extension.
+:::
+- **Description:** allows you to use the `<tr>` HTML tag in the editor
+- **Type:** Node
+
 ## TodoItem
 - **Description** It renders a single toggleable item of a list.
 - **Type:** Node


### PR DESCRIPTION
Most of the command documentation is copied from Prosemirror source.