### PR TITLE
End template tag with /

### DIFF
--- a/guide/editor.md
+++ b/guide/editor.md
@@ -9,7 +9,7 @@ You must create an instance of `Editor` class and pass it to the `EditorContent`
 ```vue
 <template>
   <editor-content :editor="editor" />
-<template>
+</template>
 
 <script>
 import { Editor, EditorContent } from 'tiptap'


### PR DESCRIPTION
The template tag was not ended in the doc example.